### PR TITLE
Fix "git checkout" failure (wrong directory)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ run apk add --update \
 
 RUN cd / \
  && git clone https://github.com/lukas2511/dehydrated.git \
- && git checkout tags/v0.5.0 \
+ && (cd dehydrated && git checkout tags/v0.5.0) \
  # need to install boto3 explicitly. For some reason dns-lexicon[route53] doesn't seem to do it
  && pip install dns-lexicon dns-lexicon[route53] boto3
 


### PR DESCRIPTION
[INF-1540](https://salemove.atlassian.net/browse/INF-1540)

FIx for https://github.com/salemove/letsencrypt-dns/pull/1. Docker image failed to build because the directory was not changed:
```
 ---> Running in 227ae32e91e4
Cloning into 'dehydrated'...
fatal: Not a git repository (or any of the parent directories): .git
```