### PR TITLE
Pin dns-lexicon version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd / \
  && git clone https://github.com/lukas2511/dehydrated.git \
  && (cd dehydrated && git checkout tags/v0.5.0) \
  # need to install boto3 explicitly. For some reason dns-lexicon[route53] doesn't seem to do it
- && pip install dns-lexicon dns-lexicon[route53] boto3
+ && pip install dns-lexicon==2.1.24 dns-lexicon[route53]==2.1.24 boto3
 
 ADD https://raw.githubusercontent.com/AnalogJ/lexicon/5deaca503010e1cc0dfca10e31f3ffd17e7fc749/examples/dehydrated.default.sh /dehydrated/
 RUN chmod +x /dehydrated/dehydrated.default.sh


### PR DESCRIPTION
`letsencrypt-dns` Docker image has been recently [re-built](https://ci.at.samo.io/job/letsencrypt-dns/7/), and the new image pulled latest version of `dns-lexicon`, which turned out to have breaking changes, rendering Docker image unusable.

Pinned the version to 2.1.24, the one used before the image was re-built. The image with the pinned version has been tested manually.