### PR TITLE
Add wildcard support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ run apk add --update \
         py-pip \
         python
 
-# Was 0.5.0
 RUN cd / \
  && git clone https://github.com/lukas2511/dehydrated.git \
  && (cd dehydrated && git checkout tags/v0.6.2) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ run apk add --update \
         py-pip \
         python
 
+# Was 0.5.0
 RUN cd / \
  && git clone https://github.com/lukas2511/dehydrated.git \
- && (cd dehydrated && git checkout tags/v0.5.0) \
+ && (cd dehydrated && git checkout tags/v0.6.2) \
  # need to install boto3 explicitly. For some reason dns-lexicon[route53] doesn't seem to do it
  && pip install dns-lexicon==2.1.24 dns-lexicon[route53]==2.1.24 boto3
 
@@ -20,4 +21,4 @@ RUN chmod +x /dehydrated/dehydrated.default.sh
 ADD dns-certbot.sh /dns-certbot.sh
 RUN chmod +x /dns-certbot.sh
 
-ENTRYPOINT  [ "/dns-certbot.sh" ]
+CMD  [ "/dns-certbot.sh" ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ if PROVIDER is set to `route53`
 * `CERTBOT_STAGING` - if set to anything but `False`, requests a fake certificate,
 not subject to rate limits.
 * `CERTBOT_DELEGATED` - if specified, indicates the part of the domain delegated to another DNS authority. `False` is equivalent to not set.
+* `CERTBOT_ALIAS` - if specified, sets the name of the directory under `/certs` to be used.
+
+`CERTBOT_ALIAS` is required to request wildcard certificates.
 
 ## Volumes
 

--- a/dns-certbot.sh
+++ b/dns-certbot.sh
@@ -11,6 +11,7 @@ DEHYDRATED_HOOK="$DEHYDRATED_DIR/dehydrated.default.sh"
 shopt -s nocasematch
 if [[ "${CERTBOT_STAGING:-"False"}" != "False" ]]; then
   sed -i 's|="https://acme-v01.api.|="https://acme-staging.api.|g' "$DEHYDRATED_EXECUTABLE"
+  sed -i 's|="https://acme-v02.api.|="https://acme-staging-v02.api.|g' "$DEHYDRATED_EXECUTABLE"
 fi
 
 # if delegated domain provided, add it to the hook
@@ -19,7 +20,7 @@ if [[ "${CERTBOT_DELEGATED:-"False"}" != "False" ]]; then
 fi
 
 CERTBOT_ALIAS_ARG=
-if [ -n ${CERTBOT_ALIAS} ]; then
+if [[ -n "${CERTBOT_ALIAS:-}" ]]; then
   CERTBOT_ALIAS_ARG="--alias $CERTBOT_ALIAS"
 fi
 
@@ -30,7 +31,7 @@ grep -A2 "# Default values" "$DEHYDRATED_EXECUTABLE"
 
 while :;
 do
-    "$DEHYDRATED_EXECUTABLE" --cron --accept-terms --hook "$DEHYDRATED_HOOK" --challenge dns-01 --domain "$CERTBOT_DOMAIN" --out "$OUTPUT_LOCATION" $CERTBOT_ALIAS_ARG
+  "$DEHYDRATED_EXECUTABLE" --cron --accept-terms --hook "$DEHYDRATED_HOOK" --challenge dns-01 --domain "$CERTBOT_DOMAIN" --out "$OUTPUT_LOCATION" $CERTBOT_ALIAS_ARG
   echo "Sleeping for $SLEEP_TIME until next check."
   sleep "$SLEEP_TIME"
 done

--- a/dns-certbot.sh
+++ b/dns-certbot.sh
@@ -17,6 +17,12 @@ fi
 if [[ "${CERTBOT_DELEGATED:-"False"}" != "False" ]]; then
  sed -i 's|lexicon \$PROVIDER|lexicon --delegated="${CERTBOT_DELEGATED}" $PROVIDER|g' "$DEHYDRATED_HOOK"
 fi
+
+CERTBOT_ALIAS_ARG=
+if [ -n ${CERTBOT_ALIAS} ]; then
+  CERTBOT_ALIAS_ARG="--alias $CERTBOT_ALIAS"
+fi
+
 shopt -u nocasematch
 
 echo "Config fragment:"
@@ -24,7 +30,7 @@ grep -A2 "# Default values" "$DEHYDRATED_EXECUTABLE"
 
 while :;
 do
-  "$DEHYDRATED_EXECUTABLE" --cron --accept-terms --hook "$DEHYDRATED_HOOK" --challenge dns-01 --domain "$CERTBOT_DOMAIN" --out "$OUTPUT_LOCATION"
+    "$DEHYDRATED_EXECUTABLE" --cron --accept-terms --hook "$DEHYDRATED_HOOK" --challenge dns-01 --domain "$CERTBOT_DOMAIN" --out "$OUTPUT_LOCATION" $CERTBOT_ALIAS_ARG
   echo "Sleeping for $SLEEP_TIME until next check."
   sleep "$SLEEP_TIME"
 done

--- a/wildcard-example
+++ b/wildcard-example
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# In your environment, you should have these defined:
+
+#AWS_ACCESS_KEY="AAAAAAAAAAAAAAAAAAAA"
+#AWS_ACCESS_SECRET="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+# STAGING=False
+STAGING=True
+
+docker run -e PROVIDER=route53 \
+       -e LEXICON_ROUTE53_ACCESS_KEY="$AWS_ACCESS_KEY_ID" \
+       -e LEXICON_ROUTE53_ACCESS_SECRET="$AWS_SECRET_ACCESS_KEY" \
+       -e CERTBOT_DOMAIN="*.z.example.com" \
+       -e CERTBOT_STAGING="$STAGING" \
+       -e CERTBOT_DELEGATED="z.example.com" \
+       -e CERTBOT_ALIAS="staging_star_z.example.com" \
+       -v /var/lib/letsencrypt-dns-staging:/certs \
+       letsencrypt_dns2

--- a/wildcard-example.sh
+++ b/wildcard-example.sh
@@ -2,8 +2,8 @@
 
 # In your environment, you should have these defined:
 
-#AWS_ACCESS_KEY="AAAAAAAAAAAAAAAAAAAA"
-#AWS_ACCESS_SECRET="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#AWS_ACCESS_KEY_ID="AAAAAAAAAAAAAAAAAAAA"
+#AWS_SECRET_ACCESS_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 # STAGING=False
 STAGING=True
@@ -16,4 +16,4 @@ docker run -e PROVIDER=route53 \
        -e CERTBOT_DELEGATED="z.example.com" \
        -e CERTBOT_ALIAS="staging_star_z.example.com" \
        -v /var/lib/letsencrypt-dns-staging:/certs \
-       letsencrypt_dns2
+       salemove/letsencrypt-dns


### PR DESCRIPTION
`dehydrated` needs v0.6.x to support wildcards. It also needs `--alias` when generating a wildcard cert.