### PR TITLE
Upgrade Lexicon and Dehydrated to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
-MAINTAINER techmovers@salemove.com
+MAINTAINER techmovers@glia.com
 
-run apk add --update \
+RUN apk add --update \
         bash \
         curl \
         git \
@@ -10,12 +10,19 @@ run apk add --update \
         python
 
 RUN cd / \
+ && apk add --no-cache --virtual .build-deps \
+    gcc \
+    python-dev \
+    musl-dev \
+    libffi-dev \
+    openssl-dev \
  && git clone https://github.com/lukas2511/dehydrated.git \
- && (cd dehydrated && git checkout tags/v0.6.2) \
+ && (cd dehydrated && git checkout tags/v0.6.5) \
  # need to install boto3 explicitly. For some reason dns-lexicon[route53] doesn't seem to do it
- && pip install dns-lexicon==2.1.24 dns-lexicon[route53]==2.1.24 boto3
+ && pip install dns-lexicon==3.2.9 dns-lexicon[route53]==3.2.9 boto3 \
+ && apk del .build-deps
 
-ADD https://raw.githubusercontent.com/AnalogJ/lexicon/5deaca503010e1cc0dfca10e31f3ffd17e7fc749/examples/dehydrated.default.sh /dehydrated/
+ADD https://raw.githubusercontent.com/AnalogJ/lexicon/d30759754272c8fa2e7426b0fe0980022318083e/examples/dehydrated.default.sh /dehydrated/
 RUN chmod +x /dehydrated/dehydrated.default.sh
 ADD dns-certbot.sh /dns-certbot.sh
 RUN chmod +x /dns-certbot.sh

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ Autonomous docker container responsible for issuing and renewing Letsencrypt cer
 ## Environment variables
 
 * `PROVIDER=route53` - optional (defaults to `cloudflare`).
-* `LEXICON_ROUTE53_ACCESS_KEY=<AWS IAM user Access Key ID>` - required
-if PROVIDER is set to `route53`
-* `LEXICON_ROUTE53_ACCESS_SECRET=<AWS IAM user Secret Key>` - required
-if PROVIDER is set to `route53`
 * `CERTBOT_DOMAIN` - the domain to get the certificate for.
 * `CERTBOT_STAGING` - if set to anything but `False`, requests a fake certificate,
 not subject to rate limits.
@@ -18,6 +14,27 @@ not subject to rate limits.
 
 `CERTBOT_ALIAS` is required to request wildcard certificates.
 
+## Credentials
+
+Credentials for the provider need to be passed via environment variables.
+Variable names format is as follows:
+
+```
+LEXICON_<PROVIDER>_<PARAMETER>
+```
+
+For example, for `PROVIDER=cloudflare` the following variables are expected (see
+[Lexicon Usage examples][1]):
+* `LEXICON_CLOUDFLARE_USERNAME`
+* `LEXICON_CLOUDFLARE_TOKEN`
+
+For `PROVIDER=route53` the following variables are expected, but they are optional
+(you can also use AWS Profile or IAM role instead of explicit credentials):
+* `LEXICON_ROUTE53_ACCESS_KEY`
+* `LEXICON_ROUTE53_ACCESS_SECRET`
+
 ## Volumes
 
 * `<your Letsencrypt certificates directory>:/certs`
+
+[1]: https://github.com/AnalogJ/lexicon/tree/d30759754272c8fa2e7426b0fe0980022318083e#usage

--- a/wildcard-example.sh
+++ b/wildcard-example.sh
@@ -2,6 +2,7 @@
 
 # In your environment, you should have these defined:
 
+# This is optional if you have an IAM role or AWS Profile:
 #AWS_ACCESS_KEY_ID="AAAAAAAAAAAAAAAAAAAA"
 #AWS_SECRET_ACCESS_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 


### PR DESCRIPTION
[INF-1941](https://salemove.atlassian.net/browse/INF-1941)

The upgrade brings two important changes:

1. No need for explicit AWS credentials anymore ([1][1]).
2. Fix for a broken APIv1 compatibility ([2][2]).

Installing `dns-lexicon` now requires dev libraries, they are purged after the process is finished to save disk space.

[1]: https://github.com/AnalogJ/lexicon/commit/8db02621defb692a5d20e10746ec916585ad743b
[2]: https://github.com/lukas2511/dehydrated/releases/tag/v0.6.5