### PR TITLE
Add custom hooks to certbot events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN cd / \
 
 ADD https://raw.githubusercontent.com/AnalogJ/lexicon/eaacd80fa8e88ec516e51dfacb7aa5a61783e6a2/examples/dehydrated.default.sh /dehydrated/
 RUN chmod +x /dehydrated/dehydrated.default.sh
+ADD hook.diff /dehydrated/
+RUN cat /dehydrated/hook.diff | patch /dehydrated/dehydrated.default.sh \
+  && chmod +x /dehydrated/dehydrated.default.sh
 ADD dns-certbot.sh /dns-certbot.sh
 RUN chmod +x /dns-certbot.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,30 @@
 FROM alpine:latest
-MAINTAINER techmovers@glia.com
+
+LABEL maintainer="techmovers@glia.com"
 
 RUN apk add --update \
         bash \
         curl \
         git \
         openssl \
-        py-pip \
-        python
+        python3
 
 RUN cd / \
  && apk add --no-cache --virtual .build-deps \
     gcc \
-    python-dev \
+    python3-dev \
     musl-dev \
     libffi-dev \
     openssl-dev \
- && git clone https://github.com/lukas2511/dehydrated.git \
+    libxml2-dev \
+    libxslt-dev \
+ && git clone https://github.com/dehydrated-io/dehydrated.git \
  && (cd dehydrated && git checkout tags/v0.6.5) \
- # need to install boto3 explicitly. For some reason dns-lexicon[route53] doesn't seem to do it
- && pip install dns-lexicon==3.2.9 dns-lexicon[route53]==3.2.9 boto3 \
+ && pip3 install pip --upgrade \
+ && pip3 install cryptography==2.8 dns-lexicon[full]==3.5.3 \
  && apk del .build-deps
 
-ADD https://raw.githubusercontent.com/AnalogJ/lexicon/d30759754272c8fa2e7426b0fe0980022318083e/examples/dehydrated.default.sh /dehydrated/
+ADD https://raw.githubusercontent.com/AnalogJ/lexicon/eaacd80fa8e88ec516e51dfacb7aa5a61783e6a2/examples/dehydrated.default.sh /dehydrated/
 RUN chmod +x /dehydrated/dehydrated.default.sh
 ADD dns-certbot.sh /dns-certbot.sh
 RUN chmod +x /dns-certbot.sh

--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ For `PROVIDER=route53` the following variables are expected, but they are option
 
 ## Volumes
 
-* `<your Letsencrypt certificates directory>:/certs`
+### Persistent certificate storage
+
+`<your Letsencrypt certificates directory>:/certs`
+
+Mounting a host volume to `/certs` makes sure the certificates issued by Letsencrypt are not gone when the docker container dies.
+
+### Custom event hooks
+
+`<your custom hooks for Letsencrypt events>:/hooks:ro`
+
+Every time Dehydrated launches certbot, it attaches a hook to each event that certbot can issue. The events are as follows:
+
+* `deploy_challenge` - called when certbot requests a domain validation
+* `clean_challenge` - called when the domain validation challenge is no longer needed
+* `invalid_challenge` - called when a domain validation has failed
+* `deploy_cert` - called when a new certificate has been issued
+* `unchanged_cert` - called when certbot has run 
+* `startup_hook` - called at the start of Dehydrated
+* `exit_hook` - called when Dehydrated exits
+
+If Dehydrated finds an executable script in `/hooks` directory with the same name as the event that triggered, it calls this script.
+For example, `/hooks/deploy_cert` can be a script that reloads `nginx` in order to pick up the new certificate.
 
 [1]: https://github.com/AnalogJ/lexicon/tree/d30759754272c8fa2e7426b0fe0980022318083e#usage

--- a/hook.diff
+++ b/hook.diff
@@ -1,0 +1,10 @@
+--- dehydrated.default.sh
++++ dehydrated.updated.sh
+@@ -152,4 +152,7 @@
+ HANDLER=$1; shift;
+ if [ -n "$(type -t $HANDLER)" ] && [ "$(type -t $HANDLER)" = function ]; then
+   $HANDLER "$@"
++  if [ -x "/hooks/$HANDLER" ]; then
++    "/hooks/$HANDLER" "$@"
++  fi
+ fi


### PR DESCRIPTION
I use this repo in my pet project and I needed to make a couple of changes that I think could be useful for Glia as well. The main change is possibility to call a hook that restarts `nginx` automatically when a new certificate has been issued.