### PR TITLE
Add Jenkinsfile to make Docker builds run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ RUN apk add --update \
         bash \
         curl \
         git \
+        patch \
         openssl \
-        python3
+        python3 \
+        py3-pip
 
 RUN cd / \
  && apk add --no-cache --virtual .build-deps \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,46 @@
+import org.jenkinsci.plugins.pipeline.github.trigger.IssueCommentCause
+
+@Library('pipeline-lib') _
+@Library('cve-monitor') __
+
+def MAIN_BRANCH = 'master'
+def DOCKER_PROJECT_NAME = 'salemove/letsencrypt-dns'
+def DOCKER_REGISTRY_URL = 'https://registry.hub.docker.com'
+def DOCKER_REGISTRY_CREDENTIALS_ID = '6992a9de-fab7-4932-9907-3aba4a70c4c0'
+
+properties([
+    pipelineTriggers([issueCommentTrigger('!build')])
+])
+def isForcePublish = !!currentBuild.rawBuild.getCause(IssueCommentCause)
+
+withResultReporting(slackChannel: '#tm-inf') {
+  inDockerAgent(containers: [imageScanner.container()]) {
+    checkout(scm)
+    def shortCommit = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+    def image
+    stage('Build docker image') {
+      ansiColor('xterm') {
+        image = docker.build("${DOCKER_PROJECT_NAME}:${shortCommit}")
+      }
+    }
+    stage('Scan docker image') {
+      imageScanner.scan(image)
+    }
+    stage('Publish docker image') {
+      docker.withRegistry(DOCKER_REGISTRY_URL, DOCKER_REGISTRY_CREDENTIALS_ID) {
+        if (BRANCH_NAME == MAIN_BRANCH || isForcePublish) {
+          echo("Publishing docker image ${image.imageName()} with tag ${shortCommit} and latest")
+          image.push("${shortCommit}")
+
+          if (isForcePublish) {
+            pullRequest.comment("Built and published `${shortCommit}`")
+          } else {
+            image.push("latest")
+          }
+        } else {
+          echo("${BRANCH_NAME} is not the master branch. Not publishing the docker image.")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Current [Jenkins job](https://ci.at.samo.io/job/letsencrypt-dns/) fails, because it's over 2 years old and expects a dedicated build slave to be present. We don't have these slaves for a long time already.

Jenkinsfile is taken from [jenkins-toolbox](https://github.com/salemove/jenkins-toolbox/blob/master/Jenkinsfile), just replaced the project name.